### PR TITLE
move account fixing to event service

### DIFF
--- a/src/main/java/romever/scan/oasisscan/repository/DebondingRepository.java
+++ b/src/main/java/romever/scan/oasisscan/repository/DebondingRepository.java
@@ -19,4 +19,6 @@ public interface DebondingRepository extends JpaRepository<Debonding, Integer>,
     List<Debonding> findByDelegatorOrderByDebondEndAsc(String delegator, Pageable pageable);
 
     long countByDelegator(String delegator);
+
+    long deleteByDelegator(String delegator);
 }

--- a/src/main/java/romever/scan/oasisscan/repository/DelegatorRepository.java
+++ b/src/main/java/romever/scan/oasisscan/repository/DelegatorRepository.java
@@ -37,4 +37,6 @@ public interface DelegatorRepository extends JpaRepository<Delegator, Integer>,
     Page<Delegator> findByDelegatorAll(String delegator, Pageable pageable);
 
     Page<Delegator> findByDelegator(String delegator, Pageable pageable);
+
+    long deleteByValidator(String validator);
 }

--- a/src/main/java/romever/scan/oasisscan/service/ScanEventService.java
+++ b/src/main/java/romever/scan/oasisscan/service/ScanEventService.java
@@ -10,6 +10,7 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 import romever.scan.oasisscan.common.ApplicationConfig;
 import romever.scan.oasisscan.common.Constants;
@@ -102,9 +103,7 @@ public class ScanEventService {
                 }
             }
 
-            for (String address : dl.getAccounts()) {
-                updateAccountInfo(address);
-            }
+            updateDirty(dl);
 
             saveScanHeight(scanHeight);
             log.info(String.format("staking events: height: %s, count: %s", scanHeight, 0));
@@ -138,6 +137,13 @@ public class ScanEventService {
         }
         if (ev.getAllowance_change() != null) {
             dl.getAccounts().add(ev.getAllowance_change().getOwner());
+        }
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    private void updateDirty(DirtyList dl) throws IOException {
+        for (String address : dl.getAccounts()) {
+            updateAccountInfo(address);
         }
     }
 

--- a/src/main/java/romever/scan/oasisscan/service/ScanValidatorService.java
+++ b/src/main/java/romever/scan/oasisscan/service/ScanValidatorService.java
@@ -216,6 +216,31 @@ public class ScanValidatorService {
     }
 
     /**
+     * Save new escrow pool balances and shares.
+     */
+    public void updateValidatorPools(String entityAddress, AccountInfo v) {
+        Optional<ValidatorInfo> optional = validatorInfoRepository.findByEntityAddress(entityAddress);
+        if (optional.isPresent()) {
+            ValidatorInfo info = optional.get();
+            AccountInfo.Escrow vEscrow = v.getEscrow();
+            if (vEscrow != null) {
+                AccountInfo.Active vActive = vEscrow.getActive();
+                if (vActive != null) {
+                    info.setEscrow(vActive.getBalance());
+                    info.setTotalShares(vActive.getTotal_shares());
+                }
+                // Currently we don't store the debonding pool info.
+            }
+            validatorInfoRepository.save(info);
+        }
+        // If we don't have a record for this validator, hold off on updating.
+        // Oasis Scan only maintains this info for registered validators, and
+        // update may come from other accounts having escrow pools.
+        // We'll get create the record later when we go through the registry
+        // changes.
+    }
+
+    /**
      * Sync entity and node relation from oasis api
      */
     @Scheduled(fixedDelay = 15 * 1000, initialDelay = 10 * 1000)

--- a/src/main/java/romever/scan/oasisscan/service/ScanValidatorService.java
+++ b/src/main/java/romever/scan/oasisscan/service/ScanValidatorService.java
@@ -512,16 +512,7 @@ public class ScanValidatorService {
                     for (Map.Entry<String, List<Debonding>> debondingEntry : debondingMap.entrySet()) {
                         String delegator = debondingEntry.getKey();
                         List<Debonding> debondingList = debondingEntry.getValue();
-                        if (!CollectionUtils.isEmpty(debondingMap)) {
-                            for (Debonding debonding : debondingList) {
-                                romever.scan.oasisscan.entity.Debonding s = new romever.scan.oasisscan.entity.Debonding();
-                                s.setValidator(validator);
-                                s.setDelegator(delegator);
-                                s.setShares(debonding.getShares());
-                                s.setDebondEnd(debonding.getDebond_end());
-                                saveList.add(s);
-                            }
-                        }
+                        saveList.addAll(getDebondings(validator, delegator, debondingList));
                     }
                 }
             }
@@ -562,6 +553,19 @@ public class ScanValidatorService {
             delegators.add(delegator);
         }
         return delegators;
+    }
+
+    public List<romever.scan.oasisscan.entity.Debonding> getDebondings(String validatorAddress, String delegatorAddress, List<Debonding> debondingList) {
+        List<romever.scan.oasisscan.entity.Debonding> debondings = Lists.newArrayList();
+        for (Debonding debonding : debondingList) {
+            romever.scan.oasisscan.entity.Debonding s = new romever.scan.oasisscan.entity.Debonding();
+            s.setValidator(validatorAddress);
+            s.setDelegator(delegatorAddress);
+            s.setShares(debonding.getShares());
+            s.setDebondEnd(debonding.getDebond_end());
+            debondings.add(s);
+        }
+        return debondings;
     }
 
     public Account getAccount(String address, AccountInfo accountInfo) {

--- a/src/main/java/romever/scan/oasisscan/service/ScanValidatorService.java
+++ b/src/main/java/romever/scan/oasisscan/service/ScanValidatorService.java
@@ -568,6 +568,16 @@ public class ScanValidatorService {
         return debondings;
     }
 
+    public List<romever.scan.oasisscan.entity.Debonding> getDebondingsForDelegator(String delegatorAddress, Map<String, List<Debonding>> debondingDelegationInfoByValidator) {
+        List<romever.scan.oasisscan.entity.Debonding> debondings = Lists.newArrayList();
+        for (Map.Entry<String, List<Debonding>> debondingDelegationsEntry : debondingDelegationInfoByValidator.entrySet()) {
+            String validatorAddress = debondingDelegationsEntry.getKey();
+            List<Debonding> debondingList = debondingDelegationsEntry.getValue();
+            debondings.addAll(getDebondings(validatorAddress, delegatorAddress, debondingList));
+        }
+        return debondings;
+    }
+
     public Account getAccount(String address, AccountInfo accountInfo) {
         Account account = accountRepository.findByAddress(address).orElse(new Account());
         account.setAddress(address);


### PR DESCRIPTION
Oasis scan already has a mechanism to fix up accounts when it sees a transaction. This PR moves that logic from the transaction scanning service to the event scanning service. Oasis events cover a broader range of account updates, including fees paid to validators and certain paratime interactions.

In future work, we can expand this to take note of what events affect which delegations and debonding delegations, and we'll be able to eliminate the validator service's use of `stakingGenesis`

Overview of the approach in this PR:

1. As we scan a block's events, generate a set of addresses that will need to be updated
2. Load the accounts for those addresses from the API and save an updated copy of them

Step 2 is currently done in a loop, but it might be nice to parallelize it.